### PR TITLE
ActorSelection for compatibility with the Quartz jobstore

### DIFF
--- a/src/Akka.Quartz.Actor.Tests/Akka.Quartz.Actor.Tests.csproj
+++ b/src/Akka.Quartz.Actor.Tests/Akka.Quartz.Actor.Tests.csproj
@@ -92,6 +92,7 @@
   <ItemGroup>
     <Compile Include="QuartzActorSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QuartzPersistentActorSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka.Quartz.Actor\Akka.Quartz.Actor.csproj">

--- a/src/Akka.Quartz.Actor.Tests/QuartzPersistentActorSpec.cs
+++ b/src/Akka.Quartz.Actor.Tests/QuartzPersistentActorSpec.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Threading;
+using Akka.Actor;
+using Akka.Quartz.Actor.Commands;
+using Akka.Quartz.Actor.Events;
+using Quartz;
+using Xunit;
+
+namespace Akka.Quartz.Actor.Tests
+{
+    public class QuartzPersistentActorSpec : TestKit.Xunit2.TestKit
+    {
+        [Fact]
+        public void QuartzPersistentActor_Should_Create_Job()
+        {
+            var probe = CreateTestProbe(Sys);
+            var quartzActor = Sys.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
+            quartzActor.Tell(new CreatePersistentJob(probe.Ref.Path, "Hello", TriggerBuilder.Create().WithCronSchedule("*0/10 * * * * ?").Build()));
+            ExpectMsg<JobCreated>();
+            probe.ExpectMsg("Hello", TimeSpan.FromSeconds(11));
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+            probe.ExpectMsg("Hello");
+            Sys.Stop(quartzActor);
+
+            
+        }
+
+        [Fact]
+        public void QuartzPersistentActor_Should_Remove_Job()
+        {
+            var probe = CreateTestProbe(Sys);
+            var quartzActor = Sys.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
+            quartzActor.Tell(new CreatePersistentJob(probe.Ref.Path, "Hello remove", TriggerBuilder.Create().WithCronSchedule("0/10 * * * * ?").Build()));
+            var jobCreated = ExpectMsg<JobCreated>();
+            probe.ExpectMsg("Hello remove", TimeSpan.FromSeconds(11));
+            quartzActor.Tell(new RemoveJob(jobCreated.JobKey, jobCreated.TriggerKey));
+            ExpectMsg<JobRemoved>();
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+            probe.ExpectNoMsg(TimeSpan.FromSeconds(10));
+            Sys.Stop(quartzActor);
+        }
+
+        [Fact]
+        public void QuartzPersistentActor_Should_Fail_With_Null_Trigger()
+        {
+            var probe = CreateTestProbe(Sys);
+            var quartzActor = Sys.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
+            quartzActor.Tell(new CreatePersistentJob(probe.Ref.Path, "Hello", null));
+            var failedJob = ExpectMsg<CreateJobFail>();
+            Assert.NotNull(failedJob.Reason);
+            Sys.Stop(quartzActor);
+        }
+
+        [Fact]
+        public void QuartzPersistentActor_Should_Fail_With_Null_Actor()
+        {
+            var quartzActor = Sys.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
+            quartzActor.Tell(new CreatePersistentJob(null, "Hello", TriggerBuilder.Create().WithCronSchedule(" * * * * * ?").Build()));
+            var failedJob = ExpectMsg<CreateJobFail>();
+            Assert.NotNull(failedJob.Reason);
+            Sys.Stop(quartzActor);
+        }
+
+        [Fact]
+        public void QuartzPersistentActor_Should_Not_Remove_UnExisting_Job()
+        {
+            var probe = CreateTestProbe(Sys);
+            var quartzActor = Sys.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
+            quartzActor.Tell(new RemoveJob(new JobKey("key"), new TriggerKey("key")));
+            ExpectMsg<RemoveJobFail>();
+            Sys.Stop(quartzActor);
+        }
+
+        [Fact]
+        public void QuartzPersistentActor_Should_Handle_New_Incarnations()
+        {
+            // setup first system
+            var firstSystem = ActorSystem.Create("test", DefaultConfig);
+            var firstProbe = CreateTestProbe(firstSystem);
+            var firstIncarnation = firstSystem.ActorOf(Props.Create(() => new Relaying(firstProbe)), "relay");
+            Watch(firstIncarnation);
+
+            var firstQuartz = firstSystem.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
+            firstQuartz.Tell(new CreatePersistentJob(firstIncarnation.Path, "Hello", TriggerBuilder.Create().WithCronSchedule("0/2 * * * * ?").Build()));
+            ExpectMsg<JobCreated>();
+            firstProbe.ExpectMsg("Hello", TimeSpan.FromSeconds(10));
+            firstSystem.Stop(firstIncarnation);
+            ExpectTerminated(firstIncarnation, TimeSpan.FromSeconds(10));
+
+            // simulate a restart
+            // use the same quartz scheduler which simulates retrieval from quartz jobstore
+            var secondSystem = ActorSystem.Create("test", DefaultConfig);
+            secondSystem.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
+            var secondProbe = CreateTestProbe(secondSystem);
+            var secondIncarnation = secondSystem.ActorOf(Props.Create(() => new Relaying(secondProbe)), "relay");
+            secondProbe.ExpectMsgFrom(secondIncarnation, "Hello", TimeSpan.FromSeconds(10));
+
+            firstSystem.Terminate();
+            secondSystem.Terminate();
+        }
+
+        private class Relaying : ReceiveActor
+        {
+            private IActorRef _relay;
+
+            public Relaying(IActorRef relay)
+            {
+                _relay = relay;
+
+                ReceiveAny(msg => _relay.Tell(msg));
+            }
+        }
+    }
+}

--- a/src/Akka.Quartz.Actor/Akka.Quartz.Actor.csproj
+++ b/src/Akka.Quartz.Actor/Akka.Quartz.Actor.csproj
@@ -65,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\CreateJob.cs" />
+    <Compile Include="Commands\CreatePersistentJob.cs" />
     <Compile Include="Commands\IJobCommand.cs" />
     <Compile Include="Commands\RemoveJob.cs" />
     <Compile Include="Events\JobCreated.cs" />
@@ -75,6 +76,8 @@
     <Compile Include="QuartzActor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuartzJob.cs" />
+    <Compile Include="QuartzPersistentActor.cs" />
+    <Compile Include="QuartzPersistentJob.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Akka.Quartz.Actor/Commands/CreatePersistentJob.cs
+++ b/src/Akka.Quartz.Actor/Commands/CreatePersistentJob.cs
@@ -1,0 +1,33 @@
+﻿using Akka.Actor;
+using Quartz;
+
+namespace Akka.Quartz.Actor.Commands
+{
+    /// <summary>
+    ///     Message to add a trigger.
+    /// </summary>
+    public class CreatePersistentJob : IJobCommand
+    {
+        public CreatePersistentJob(ActorPath to, object message, ITrigger trigger)
+        {
+            To = to;
+            Message = message;
+            Trigger = trigger;
+        }
+
+        /// <summary>
+        ///     The desination actor
+        /// </summary>
+        public ActorPath To { get; private set; }
+
+        /// <summary>
+        ///     Message
+        /// </summary>
+        public object Message { get; private set; }
+
+        /// <summary>
+        ///     Trigger 
+        /// </summary>
+        public ITrigger Trigger { get; private set; }
+    }
+}

--- a/src/Akka.Quartz.Actor/QuartzPersistentActor.cs
+++ b/src/Akka.Quartz.Actor/QuartzPersistentActor.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Akka.Actor;
+using Akka.Quartz.Actor.Commands;
+using Akka.Quartz.Actor.Events;
+using Quartz.Impl;
+using IScheduler = Quartz.IScheduler;
+
+namespace Akka.Quartz.Actor
+{
+    /// <summary>
+    /// The persistent quartz scheduling actor. Handles a single quartz scheduler
+    /// and processes CreatePersistentJob and RemoveJob messages.
+    /// </summary>
+    public class QuartzPersistentActor : QuartzActor
+    {
+        private readonly IScheduler _scheduler;
+
+        public QuartzPersistentActor()
+        {
+            _scheduler = new StdSchedulerFactory().GetScheduler();
+            if (!_scheduler.Context.ContainsKey(QuartzPersistentJob.SysKey))
+            {
+                _scheduler.Context.Add(QuartzPersistentJob.SysKey, Context.System);
+            }
+            else
+            {
+                _scheduler.Context.Remove(QuartzPersistentJob.SysKey);
+                _scheduler.Context.Add(QuartzPersistentJob.SysKey, Context.System);
+            }
+        }
+
+        protected override bool Receive(object message)
+        {
+            return message.Match().With<CreatePersistentJob>(CreateJobCommand).With<RemoveJob>(RemoveJobCommand).WasHandled;
+        }
+
+        private void CreateJobCommand(CreatePersistentJob createJob)
+        {
+            if (createJob.To == null)
+            {
+                Context.Sender.Tell(new CreateJobFail(null, null, new ArgumentNullException("createJob.To")));
+            }
+            if (createJob.Trigger == null)
+            {
+                Context.Sender.Tell(new CreateJobFail(null, null, new ArgumentNullException("createJob.Trigger")));
+            }
+            else
+            {
+
+                try
+                {
+                    var job =
+                    QuartzPersistentJob.CreateBuilderWithData(createJob.To, createJob.Message)
+                        .WithIdentity(createJob.Trigger.JobKey)
+                        .Build();
+                    _scheduler.ScheduleJob(job, createJob.Trigger);
+
+                    Context.Sender.Tell(new JobCreated(createJob.Trigger.JobKey, createJob.Trigger.Key));
+                }
+                catch (Exception ex)
+                {
+                    Context.Sender.Tell(new CreateJobFail(createJob.Trigger.JobKey, createJob.Trigger.Key, ex));
+                }
+            }
+        }
+    }
+}

--- a/src/Akka.Quartz.Actor/QuartzPersistentJob.cs
+++ b/src/Akka.Quartz.Actor/QuartzPersistentJob.cs
@@ -1,0 +1,40 @@
+using Akka.Actor;
+using Akka.Util.Internal;
+using Quartz;
+
+namespace Akka.Quartz.Actor
+{
+    /// <summary>
+    /// Persistent Job
+    /// </summary>
+    public class QuartzPersistentJob : IJob
+    {
+        private const string MessageKey = "message";
+        private const string ActorKey = "actor";
+        public const string SysKey = "sys";
+
+        public void Execute(IJobExecutionContext context)
+        {
+            var jdm = context.JobDetail.JobDataMap;
+            if (jdm.ContainsKey(MessageKey) && jdm.ContainsKey(ActorKey))
+            {
+                var actor = jdm[ActorKey] as ActorPath;
+                var sys = context.Scheduler.Context[SysKey] as ActorSystem;
+
+                if (actor != null && sys != null)
+                {
+                    ActorSelection selection = sys.ActorSelection(actor);
+
+                    selection.Tell(jdm[MessageKey]);
+                }
+            }
+        }
+
+        public static JobBuilder CreateBuilderWithData(ActorPath actorPath, object message)
+        {
+            var jdm = new JobDataMap();
+            jdm.AddAndReturn(MessageKey, message).Add(ActorKey, actorPath);
+            return JobBuilder.Create<QuartzPersistentJob>().UsingJobData(jdm);
+        }
+    }
+}


### PR DESCRIPTION
Hi,

I've made these changes to allow the jobs to be persisted in the Quartz jobstore and then to work in a new instance of application with new incarnations of the actors. 

I switched to using ActorSelection so that new incarnations of the actor can be used. Which meant I had to changed to using ActorPaths in the jobs and put a reference to the ActorSystem in the Quartz scheduler context.

This seems like a quite a big change. I wasn't sure if I should have created an issue to discuss this first so apologies if I've approached this in the wrong way.

Jas