### PR TITLE
Made the job not found exception strongly typed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.0.4 February 21 2017 ####
+Created the `JobNotFoundException` type. If a job is not found when invoking the `RemoveJob` command, 
+`RemoveJobFail` will contain an exception of this type instead of the string "job not found".
+
+
 #### 1.0.3 Januari 26 2017 ####
 updated to akka 1.1.3  
 Serializing the ActorPath and message to save in a persistent Quartz JobStore  

--- a/src/Akka.Quartz.Actor.Tests/Akka.Quartz.Actor.Tests.csproj
+++ b/src/Akka.Quartz.Actor.Tests/Akka.Quartz.Actor.Tests.csproj
@@ -44,20 +44,20 @@
       <HintPath>..\packages\Akka.TestKit.Xunit2.1.1.3\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.3.0.0\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Common.Logging.Core.3.0.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Quartz, Version=2.3.3.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
+    <Reference Include="Quartz, Version=2.4.1.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Quartz.2.4.1\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Akka.Quartz.Actor.Tests/QuartzActorSpec.cs
+++ b/src/Akka.Quartz.Actor.Tests/QuartzActorSpec.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Quartz.Actor.Commands;
 using Akka.Quartz.Actor.Events;
+using Akka.Quartz.Actor.Exceptions;
 using Quartz;
 using Xunit;
 
@@ -20,9 +21,7 @@ namespace Akka.Quartz.Actor.Tests
             probe.ExpectMsg("Hello", TimeSpan.FromSeconds(11));
             Thread.Sleep(TimeSpan.FromSeconds(10));
             probe.ExpectMsg("Hello");
-            Sys.Stop(quartzActor);
-
-            
+            Sys.Stop(quartzActor);            
         }
 
         [Fact]
@@ -67,7 +66,8 @@ namespace Akka.Quartz.Actor.Tests
             var probe = CreateTestProbe(Sys);
             var quartzActor = Sys.ActorOf(Props.Create(() => new QuartzActor()), "QuartzActor");
             quartzActor.Tell(new RemoveJob(new JobKey("key"), new TriggerKey("key")));
-            ExpectMsg<RemoveJobFail>();
+            var failure=ExpectMsg<RemoveJobFail>();
+            Assert.IsType<JobNotFoundException>(failure.Reason);
             Sys.Stop(quartzActor);
         }
     }

--- a/src/Akka.Quartz.Actor.Tests/QuartzPersistentActorSpec.cs
+++ b/src/Akka.Quartz.Actor.Tests/QuartzPersistentActorSpec.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Quartz.Actor.Commands;
 using Akka.Quartz.Actor.Events;
+using Akka.Quartz.Actor.Exceptions;
 using Quartz;
 using Xunit;
 
@@ -20,9 +21,7 @@ namespace Akka.Quartz.Actor.Tests
             probe.ExpectMsg("Hello", TimeSpan.FromSeconds(11));
             Thread.Sleep(TimeSpan.FromSeconds(10));
             probe.ExpectMsg("Hello");
-            Sys.Stop(quartzActor);
-
-            
+            Sys.Stop(quartzActor);            
         }
 
         [Fact]
@@ -67,7 +66,8 @@ namespace Akka.Quartz.Actor.Tests
             var probe = CreateTestProbe(Sys);
             var quartzActor = Sys.ActorOf(Props.Create(() => new QuartzPersistentActor()), "QuartzActor");
             quartzActor.Tell(new RemoveJob(new JobKey("key"), new TriggerKey("key")));
-            ExpectMsg<RemoveJobFail>();
+            var failure=ExpectMsg<RemoveJobFail>();
+            Assert.IsType<JobNotFoundException>(failure.Reason);
             Sys.Stop(quartzActor);
         }
 

--- a/src/Akka.Quartz.Actor.Tests/packages.config
+++ b/src/Akka.Quartz.Actor.Tests/packages.config
@@ -3,10 +3,10 @@
   <package id="Akka" version="1.1.3" targetFramework="net452" />
   <package id="Akka.TestKit" version="1.1.3" targetFramework="net452" />
   <package id="Akka.TestKit.Xunit2" version="1.1.3" targetFramework="net452" />
-  <package id="Common.Logging" version="3.0.0" targetFramework="net452" />
-  <package id="Common.Logging.Core" version="3.0.0" targetFramework="net452" />
+  <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
+  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="Quartz" version="2.3.3" targetFramework="net452" />
+  <package id="Quartz" version="2.4.1" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/src/Akka.Quartz.Actor/Akka.Quartz.Actor.csproj
+++ b/src/Akka.Quartz.Actor/Akka.Quartz.Actor.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Quartz, Version=2.3.3.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
+    <Reference Include="Quartz, Version=2.4.1.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Quartz.2.4.1\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -73,6 +73,7 @@
     <Compile Include="Events\IJobEvent.cs" />
     <Compile Include="Events\JobEvent.cs" />
     <Compile Include="Events\RemoveJobFail.cs" />
+    <Compile Include="Exceptions\JobNotFoundException.cs" />
     <Compile Include="QuartzActor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuartzJob.cs" />

--- a/src/Akka.Quartz.Actor/Exceptions/JobNotFoundException.cs
+++ b/src/Akka.Quartz.Actor/Exceptions/JobNotFoundException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Akka.Quartz.Actor.Exceptions
+{
+    public class JobNotFoundException: Exception
+    {
+        public JobNotFoundException() : base("job not found")
+        {            
+        }
+    }
+}

--- a/src/Akka.Quartz.Actor/QuartzActor.cs
+++ b/src/Akka.Quartz.Actor/QuartzActor.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using Akka.Actor;
 using Akka.Quartz.Actor.Commands;
 using Akka.Quartz.Actor.Events;
+using Akka.Quartz.Actor.Exceptions;
 using Quartz;
 using Quartz.Impl;
 using IScheduler = Quartz.IScheduler;
@@ -62,11 +63,11 @@ namespace Akka.Quartz.Actor
         {
             if (createJob.To == null)
             {
-                Context.Sender.Tell(new CreateJobFail(null, null, new ArgumentNullException("createJob.To")));
+                Context.Sender.Tell(new CreateJobFail(null, null, new ArgumentNullException(nameof(createJob.To))));
             }
             if (createJob.Trigger == null)
             {
-                Context.Sender.Tell(new CreateJobFail(null, null, new ArgumentNullException("createJob.Trigger")));
+                Context.Sender.Tell(new CreateJobFail(null, null, new ArgumentNullException(nameof(createJob.Trigger))));
             }
             else
             {
@@ -99,7 +100,7 @@ namespace Akka.Quartz.Actor
                 }
                 else
                 {
-                    Context.Sender.Tell(new RemoveJobFail(removeJob.JobKey, removeJob.TriggerKey, new Exception("job not found")));
+                    Context.Sender.Tell(new RemoveJobFail(removeJob.JobKey, removeJob.TriggerKey, new JobNotFoundException()));
                 }
             }
             catch (Exception ex)

--- a/src/Akka.Quartz.Actor/packages.config
+++ b/src/Akka.Quartz.Actor/packages.config
@@ -4,6 +4,6 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="Quartz" version="2.3.3" targetFramework="net452" />
+  <package id="Quartz" version="2.4.1" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
 </packages>

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 [assembly: AssemblyCompanyAttribute("Akka.NET Team")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2013-2016 Akka.NET Team")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.0.3.0")]
-[assembly: AssemblyFileVersionAttribute("1.0.3.0")]
+[assembly: AssemblyVersionAttribute("1.0.4.0")]
+[assembly: AssemblyFileVersionAttribute("1.0.4.0")]


### PR DESCRIPTION
This PR was made to address issue #29 

Additionally I consolidated the package versions in the solution so that version conflicts would not appear
Finally I modified the argument null exceptions such that they use the nameof operator to get the names of the variables instead of requiring manual var name syncing