### PR TITLE
Update Akka package to 1.3.1

### DIFF
--- a/src/Akka.Quartz.Actor.IntegrationTests/Akka.Quartz.Actor.IntegrationTests.csproj
+++ b/src/Akka.Quartz.Actor.IntegrationTests/Akka.Quartz.Actor.IntegrationTests.csproj
@@ -33,11 +33,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.2.3.41, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.3.1\lib\net45\Akka.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.2.3.41, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.2.3\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.3.1\lib\net45\Akka.TestKit.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Akka.TestKit.Xunit2, Version=1.2.3.41, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.TestKit.Xunit2.1.2.3\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>

--- a/src/Akka.Quartz.Actor.IntegrationTests/packages.config
+++ b/src/Akka.Quartz.Actor.IntegrationTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net452" />
-  <package id="Akka.TestKit" version="1.2.3" targetFramework="net452" />
+  <package id="Akka" version="1.3.1" targetFramework="net452" />
+  <package id="Akka.TestKit" version="1.3.1" targetFramework="net452" />
   <package id="Akka.TestKit.Xunit2" version="1.2.3" targetFramework="net452" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />

--- a/src/Akka.Quartz.Actor.Tests/Akka.Quartz.Actor.Tests.csproj
+++ b/src/Akka.Quartz.Actor.Tests/Akka.Quartz.Actor.Tests.csproj
@@ -32,11 +32,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.2.3.41, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.3.1\lib\net45\Akka.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Akka.TestKit, Version=1.2.3.41, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.TestKit.1.2.3\lib\net45\Akka.TestKit.dll</HintPath>
+    <Reference Include="Akka.TestKit, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.3.1\lib\net45\Akka.TestKit.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Akka.TestKit.Xunit2, Version=1.2.3.41, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Akka.TestKit.Xunit2.1.2.3\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>

--- a/src/Akka.Quartz.Actor.Tests/packages.config
+++ b/src/Akka.Quartz.Actor.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net452" />
-  <package id="Akka.TestKit" version="1.2.3" targetFramework="net452" />
+  <package id="Akka" version="1.3.1" targetFramework="net452" />
+  <package id="Akka.TestKit" version="1.3.1" targetFramework="net452" />
   <package id="Akka.TestKit.Xunit2" version="1.2.3" targetFramework="net452" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />

--- a/src/Akka.Quartz.Actor/Akka.Quartz.Actor.csproj
+++ b/src/Akka.Quartz.Actor/Akka.Quartz.Actor.csproj
@@ -30,8 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.2.3.41, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Akka.1.2.3\lib\net45\Akka.dll</HintPath>
+    <Reference Include="Akka, Version=1.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.3.1\lib\net45\Akka.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>

--- a/src/Akka.Quartz.Actor/packages.config
+++ b/src/Akka.Quartz.Actor/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.2.3" targetFramework="net452" />
+  <package id="Akka" version="1.3.1" targetFramework="net452" />
   <package id="Common.Logging" version="3.3.1" targetFramework="net452" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />


### PR DESCRIPTION
After upgrading Akka packages to 1.3.1 it is no longer possible to schedule messages with Akka.Quartz.Actor using Hyperion, the jobs fail with the error "System.MissingMethodException: Method not found: 'Akka.Serialization.Serializer Akka.Serialization.Serialization.FindSerializerFor(System.Object)". Upgrading Akka.Quartz.Actor to use Akka.NET 1.3.1 solved this issue.