### PR TITLE
[docs] Update site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ For more information, please see the unit test.
 
 For more information about quartz scheduler please see
 http://www.quartz-scheduler.net/documentation/
-For more information about akka .net please see
-http://getakka.net/docs/
+For more information about akka.net please see
+https://getakka.net/articles/intro/what-is-akka.html


### PR DESCRIPTION
This PR updates the link to the getakka.net site. 

It was pointing to a path from the old site.