### PR TITLE
Use same serializers (object) for both serialization and deserialization

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -16,6 +16,10 @@ jobs:
         clean: false  # whether to fetch clean each time
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
+      - task: UseDotNet@2
+        displayName: "Use .NET SDK 3.1"
+        inputs:
+          version: 3.1.x
       # Linux or macOS
       - task: Bash@3 
         displayName: Linux / OSX Build

--- a/build-system/linux-pr-validation.yaml
+++ b/build-system/linux-pr-validation.yaml
@@ -17,6 +17,6 @@ jobs:
 - template: azure-pipeline.template.yaml
   parameters:
     name: Ubuntu
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-latest'
     scriptFileName: ./build.sh
     scriptArgs: all

--- a/build-system/windows-pr-validation.yaml
+++ b/build-system/windows-pr-validation.yaml
@@ -17,6 +17,6 @@ jobs:
 - template: azure-pipeline.template.yaml
   parameters:
     name: Windows
-    vmImage: 'windows-2019'
+    vmImage: 'windows-latest'
     scriptFileName: build.cmd
     scriptArgs: all

--- a/src/Akka.Quartz.Actor/QuartzPersistentJob.cs
+++ b/src/Akka.Quartz.Actor/QuartzPersistentJob.cs
@@ -35,7 +35,7 @@ namespace Akka.Quartz.Actor
 
         public static JobBuilder CreateBuilderWithData(ActorPath actorPath, object message, ActorSystem system)
         {
-            Serializer messageSerializer = system.Serialization.FindSerializerFor(message);
+            Serializer messageSerializer = system.Serialization.FindSerializerForType(typeof(object));
             var serializedMessage = messageSerializer.ToBinary(message);
             var serializedPath = actorPath.ToSerializationFormat();
             var jdm = new JobDataMap();


### PR DESCRIPTION
Fixes #311 

## Changes

This PR chooses same serializer (object) for both serialization and deserialization.

## Checklist

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
