### PR TITLE
Update release script

### DIFF
--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -22,15 +22,18 @@ variables:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET Core Runtime 3.1.10'
+  displayName: 'Use .NET 6'
   inputs:
-    packageType: runtime
-    version: 3.1.10
+    version: '6.x'
+- task: UseDotNet@2
+  displayName: 'Use .NET Core 3.1'
+  inputs:
+    version: 3.1.x
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:
     filename: build.cmd
-    arguments: 'All nugetpublishurl=https://api.nuget.org/v3/index.json nugetkey=$(nugetKey)'
+    arguments: 'nuget nugetpublishurl=https://api.nuget.org/v3/index.json nugetkey=$(nugetKey)'
 
 - task: GitHubRelease@0
   displayName: 'GitHub release (create)'


### PR DESCRIPTION
Fix release script, could not find .NET 6.0

```
Testhost process for source(s) 'D:\a\1\s\src\Akka.Quartz.Actor.Tests\bin\Release\net6.0\Akka.Quartz.Actor.Tests.dll' exited with error: It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '6.0.0' was not found.
  - The following frameworks were found:
      3.1.10 at [C:\hostedtoolcache\windows\dotnet\shared\Microsoft.NETCore.App]
```