### PR TITLE
Support deserialization of job messages via SerializerWithStringManif…

### DIFF
--- a/src/Akka.Quartz.Actor/QuartzPersistentJob.cs
+++ b/src/Akka.Quartz.Actor/QuartzPersistentJob.cs
@@ -13,11 +13,11 @@ namespace Akka.Quartz.Actor
     {
         private const string MessageKey = "message";
         private const string ActorKey = "actor";
+        private const string ManifestKey = "manifest";
         public const string SysKey = "sys";
 
         public Task Execute(IJobExecutionContext context)
         {
-
             var jdm = context.JobDetail.JobDataMap;
             if (jdm.ContainsKey(MessageKey) && jdm.ContainsKey(ActorKey))
             {
@@ -25,7 +25,31 @@ namespace Akka.Quartz.Actor
                 {
                     ActorSelection selection = sys.ActorSelection(actorPath);
                     byte[] messageBytes = jdm[MessageKey] as byte[];
-                    var message = sys.Serialization.FindSerializerForType(typeof(object)).FromBinary(messageBytes, typeof(object));
+
+                    var serializer = sys.Serialization.FindSerializerForType(typeof(object));
+                    object message;
+
+                    if (jdm.ContainsKey(ManifestKey) && !string.IsNullOrEmpty(jdm[ManifestKey] as string))
+                    {
+                        var manifest = jdm[ManifestKey] as string;
+
+                        if (serializer is SerializerWithStringManifest sm)
+                        {
+                            message = sm.FromBinary(messageBytes, manifest);
+                        }
+                        else
+                        {
+                            var type = System.Type.GetType(manifest);
+                            if (type == null) type = typeof(object);
+
+                            message = serializer.FromBinary(messageBytes, type);
+                        }
+                    }
+                    else
+                    {
+                        message = serializer.FromBinary(messageBytes, typeof(object));
+                    }
+
                     selection.Tell(message);
                 }
             }
@@ -36,10 +60,16 @@ namespace Akka.Quartz.Actor
         public static JobBuilder CreateBuilderWithData(ActorPath actorPath, object message, ActorSystem system)
         {
             Serializer messageSerializer = system.Serialization.FindSerializerForType(typeof(object));
+            var manifest = Serialization.Serialization.ManifestFor(messageSerializer, message);
             var serializedMessage = messageSerializer.ToBinary(message);
             var serializedPath = actorPath.ToSerializationFormat();
+
             var jdm = new JobDataMap();
-            jdm.AddAndReturn(MessageKey, serializedMessage).Add(ActorKey, serializedPath);
+            jdm
+                .AddAndReturn(MessageKey, serializedMessage)
+                .AddAndReturn(ActorKey, serializedPath)
+                .Add(ManifestKey, manifest);
+
             return JobBuilder.Create<QuartzPersistentJob>().UsingJobData(jdm);
         }
     }


### PR DESCRIPTION
Support deserialization of job messages via `SerializerWithStringManifest` or `Serializer` when `IncludeManifest = true`.

Fixes https://github.com/akkadotnet/Akka.Quartz.Actor/issues/334

## Changes

This change allows for custom serializers defined with `SerializerWithStringManifest` or `Serializer` when `IncludeManifest = true` to have the appropriate type info passed into `FromBinary`.  The manifest type info is saved during job creation, allowing the deserialization process to support the manifest type hint provided by a custom serializer.

This PR is related to another issue https://github.com/akkadotnet/Akka.Quartz.Actor/issues/215 but I don't think it's quite the same. From reading @object comments on the state of that issue I believe the remaining piece to solve there is allowing Akka.Hosting `.WithCustomSerializer` (or hocon config) to associate a custom serializer with a specific type (other than System.Object).  My PR still requires config to associate a custom serializer with System.Object, rather than a more refined type.
