### PR TITLE
Changed quartz.serializer.type in integration tests from "binary" to "newtonsoft" and updated dependencies

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 1.5.33 January 3 2025 ####
+
+* [Update Akka.NET to v1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
+* Updated .NET test version to 8.0
+* Changed quartz.serializer.type in integration tests from "binary" to "newtonsoft" (binary formatter is deprecated in Quartz.NET and .NET)
+
 #### 1.5.13 October 4 2023 ####
 
 * [Update Akka.NET to v1.5.13](https://github.com/akkadotnet/akka.net/releases/tag/1.5.13)

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -21,9 +21,9 @@ jobs:
         inputs:
           version: 3.1.x
       - task: UseDotNet@2
-        displayName: "Use .NET 6.0 SDK"
+        displayName: "Use .NET 8.0 SDK"
         inputs:
-          version: 6.x
+          version: 8.x
       # Linux or macOS
       - task: Bash@3 
         displayName: Linux / OSX Build

--- a/build.fsx
+++ b/build.fsx
@@ -37,7 +37,7 @@ let outputNuGet = output @@ "nuget"
 
 // Configuration values for tests
 let testNetFrameworkVersion = "net472"
-let testNetVersion = "net6.0"
+let testNetVersion = "net8.0"
 
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"

--- a/src/Akka.Quartz.Actor.IntegrationTests/Akka.Quartz.Actor.IntegrationTests.csproj
+++ b/src/Akka.Quartz.Actor.IntegrationTests/Akka.Quartz.Actor.IntegrationTests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Quartz.Serialization.Json" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Akka.TestKit.Xunit2" />

--- a/src/Akka.Quartz.Actor.IntegrationTests/QuartzPersistentActorIntegration.cs
+++ b/src/Akka.Quartz.Actor.IntegrationTests/QuartzPersistentActorIntegration.cs
@@ -51,7 +51,7 @@ namespace Akka.Quartz.Actor.IntegrationTests
                 ["quartz.dataSource.default.provider"] = "sqlite-custom",
                 ["quartz.dataSource.default.connectionString"] = "Data Source=quartz-jobs.db",
                 ["quartz.jobStore.lockHandler.type"] = "Quartz.Impl.AdoJobStore.UpdateLockRowSemaphore, Quartz",
-                ["quartz.serializer.type"] = "binary"
+                ["quartz.serializer.type"] = "newtonsoft"
             };
 
             ISchedulerFactory sf = new StdSchedulerFactory(properties);

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <NetFrameworkTestVersion>net472</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
-    <NetTestVersion>net6.0</NetTestVersion>
+    <NetTestVersion>net8.0</NetTestVersion>
   </PropertyGroup>
   <!-- GitHub SourceLink -->
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,29 +1,30 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.13</AkkaVersion>
+    <AkkaVersion>1.5.33</AkkaVersion>
   </PropertyGroup>
-
   <!-- App dependencies -->
   <ItemGroup>
     <PackageVersion Include="Akka" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Quartz" Version="3.7.0" />
+    <PackageVersion Include="Quartz" Version="3.13.1" />
+    <PackageVersion Include="Quartz.Serialization.Json" Version="3.13.1" />
   </ItemGroup>
-
   <!-- Test dependencies -->
   <ItemGroup>
-    <PackageVersion Include="EntityFramework" Version="6.4.4" />
+    <PackageVersion Include="EntityFramework" Version="6.5.1" />
     <PackageVersion Condition="'$(TargetFramework)' == 'net472'" Include="Microsoft.Data.Sqlite" Version="2.2.6" />
-    <PackageVersion Condition="'$(TargetFramework)' != 'net472'" Include="Microsoft.Data.Sqlite" Version="7.0.11" />
+    <PackageVersion Condition="'$(TargetFramework)' != 'net472'" Include="Microsoft.Data.Sqlite" Version="9.0.0" />
     <PackageVersion Include="Akka.Hosting.TestKit" Version="$(AkkaVersion)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="Akka.TestKit.Xunit2" Version="$(AkkaVersion)" />
   </ItemGroup>
-
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Changes

The main change in this PR is replacing "quartz.serializer.type" in integration tests from "binary" to "newtonsoft". Use of binary serializer required BinaryFormatter that has been deprecated in .NET 8 and removed in .NET 9. Because of that "binary" serializer has been also deprecate in Quartz.NET, instead either Newtonsoft.Json or System.Text.Json should be used.

More information:

https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/binaryformatter-disabled

https://www.quartz-scheduler.net/documentation/quartz-3.x/packages/json-serialization.html
