### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Directory.Generated.props
+++ b/Directory.Generated.props
@@ -1,8 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.5.33</VersionPrefix>
-    <PackageReleaseNotes>* [Update Akka.NET to v1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
-* Updated .NET test version to 8.0
-* Changed quartz.serializer.type in integration tests from "binary" to "newtonsoft" (binary formatter is deprecated in Quartz.NET and .NET)</PackageReleaseNotes>
+    <VersionPrefix>1.5.59</VersionPrefix>
+    <PackageReleaseNotes>* [Update Akka.NET to v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.33</AkkaVersion>
+    <AkkaVersion>1.5.59</AkkaVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.59 January 26 2026 ####
+
+* [Update Akka.NET to v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
+
 #### 1.5.33 January 3 2025 ####
 
 * [Update Akka.NET to v1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)


### PR DESCRIPTION
## Summary
- Upgrade Akka.NET to 1.5.59

## Changes
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)