### PR TITLE
Update Akka.NET to 1.5.60

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <AkkaVersion>1.5.59</AkkaVersion>
+    <AkkaVersion>1.5.60</AkkaVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Update AkkaVersion from 1.5.59 to 1.5.60 in Directory.Packages.props

## Test plan
- [x] Build succeeds in Release mode
- [x] All unit tests pass (11 tests)
- [x] All integration tests pass (1 test)